### PR TITLE
refactor: make error component sticky instead of fixed

### DIFF
--- a/cypress/integration/projects/laura-lea.ts
+++ b/cypress/integration/projects/laura-lea.ts
@@ -100,10 +100,6 @@ context('Laura Lea', () => {
     cy.get(elements.error)
       .should('be.visible')
       .and('contain.text', 'an error occurred');
-    cy.contains(elements.errorGlobalText).scrollIntoView({
-      offset: { top: 200, left: 0 },
-    });
-    cy.get(elements.error).should('not.be.visible');
   });
 
   it('should display hover', () => {

--- a/src/partials/laura-lea/error/error.spec.tsx
+++ b/src/partials/laura-lea/error/error.spec.tsx
@@ -89,19 +89,9 @@ describe('`Error`', () => {
       it('should set `type` as global if global text is visible', () => {
         (useVisible as jest.Mock).mockReturnValueOnce([() => undefined, false]);
         (useVisible as jest.Mock).mockReturnValueOnce([() => undefined, true]);
-        (useVisible as jest.Mock).mockReturnValueOnce([() => undefined, false]);
         comp.rerender(<Error />);
 
         expect(Page.errorComponent!.getAttribute('type')).toBe('global');
-      });
-
-      it('should set `type` as `undefined` if end is visible', () => {
-        (useVisible as jest.Mock).mockReturnValueOnce([() => undefined, false]);
-        (useVisible as jest.Mock).mockReturnValueOnce([() => undefined, false]);
-        (useVisible as jest.Mock).mockReturnValueOnce([() => undefined, true]);
-        comp.rerender(<Error />);
-
-        expect(Page.errorComponent!.getAttribute('type')).toBeFalsy();
       });
     });
   });

--- a/src/partials/laura-lea/error/error.styles.ts
+++ b/src/partials/laura-lea/error/error.styles.ts
@@ -4,12 +4,9 @@ export const Error = styled.div`
   overflow: visible;
   position: relative;
   min-height: 100vh;
-  padding: 10vh 0;
+  padding: 30vh 0 10vh;
 
   component-error {
-    position: fixed;
-    left: 0;
-    right: 0;
     z-index: 8;
   }
 `;

--- a/src/partials/laura-lea/error/error.tsx
+++ b/src/partials/laura-lea/error/error.tsx
@@ -40,15 +40,10 @@ const Error: FC = () => {
 
   const [appVisibleRef, appIsVisible] = useVisible();
   const [globalVisibleRef, globalIsVisible] = useVisible();
-  const [endRef, endIsVisible] = useVisible();
 
   useEffect(() => {
     globalIsVisible && setErrorType('global');
   }, [globalIsVisible]);
-
-  useEffect(() => {
-    endIsVisible && setErrorType(undefined);
-  }, [endIsVisible]);
 
   useComponent(errorComponent, appIsVisible);
 
@@ -101,8 +96,6 @@ const Error: FC = () => {
           </p>
         </Text>
       </Container>
-
-      <div ref={endRef} style={{ marginTop: '50vh' }} />
     </ErrorStyled>
   );
 };


### PR DESCRIPTION
Previously, error component was position fixed, which meant that at the end of the section, a `useVisible` would have to set the error type to `undefined`. This commit makes it position sticky instead, which removes the need for the extra logic