### PR TITLE
fix: polyfill smooth `scrollIntoView`

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,7 @@
 import './src/styles/reset.css';
 import './src/styles/global.css';
 
+import smoothscroll from 'smoothscroll-polyfill';
 import 'zone.js/dist/zone';
 import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter';
 import { init } from '@sentry/react';
@@ -14,6 +15,8 @@ init({
   environment: process.env.NODE_ENV,
   enabled: process.env.NODE_ENV !== 'development',
 });
+
+smoothscroll.polyfill();
 
 // eslint-disable-next-line react/prop-types
 export const wrapPageElement = ({ element }) => <Root>{element}</Root>;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-helmet": "^6.0.0-beta.2",
     "react-spring": "^8.0.27",
     "rxjs": "6.6.3",
+    "smoothscroll-polyfill": "^0.4.4",
     "tslib": "^1.13.0",
     "zone.js": "0.10.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14829,6 +14829,11 @@ slugify@^1.4.0:
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
   integrity sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==
 
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
`scrollIntoView` `smooth` isnt natively supported by safari and IE