### PR TITLE
fix: ssr pages should have correct styles

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,9 +5,6 @@ import smoothscroll from 'smoothscroll-polyfill';
 import 'zone.js/dist/zone';
 import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter';
 import { init } from '@sentry/react';
-import React from 'react';
-
-import { Root } from './src/components/root';
 
 init({
   dsn:
@@ -17,9 +14,6 @@ init({
 });
 
 smoothscroll.polyfill();
-
-// eslint-disable-next-line react/prop-types
-export const wrapPageElement = ({ element }) => <Root>{element}</Root>;
 
 export const shouldUpdateScroll = ({
   routerProps: {
@@ -35,3 +29,5 @@ export const shouldUpdateScroll = ({
   nextIntro.scrollIntoView({ behavior: 'smooth' });
   return false;
 };
+
+export { wrapPageElement } from './src/components/root';

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,1 @@
+export { wrapPageElement } from './src/components/root';

--- a/src/components/root.spec.tsx
+++ b/src/components/root.spec.tsx
@@ -24,7 +24,7 @@ class Page {
 
 function setupTest(): void {
   render(
-    <Root>
+    <Root path="/path">
       <div>Content</div>
     </Root>
   );

--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, FC, ReactNode } from 'react';
-import { InferProps, element } from 'prop-types';
+import { InferProps, shape, string } from 'prop-types';
+import { WrapPageElementBrowserArgs } from 'gatsby';
 
 import {
   animated,
@@ -9,12 +10,13 @@ import {
 } from 'react-spring';
 
 const propTypes = {
-  children: element.isRequired,
+  path: string.isRequired,
+  children: shape({}).isRequired,
 };
 type Props = InferProps<typeof propTypes>;
 
-const Root: FC<Props> = ({ children }) => {
-  const transitions = useTransition(children, children.key, {
+const Root: FC<Props> = ({ path, children }) => {
+  const transitions = useTransition(children, path, {
     from: { transform: 'translateY(0%)' },
     leave: { transform: 'translateY(-100%)' },
     config: config.slow,
@@ -35,4 +37,9 @@ const Root: FC<Props> = ({ children }) => {
 
 Root.propTypes = propTypes;
 
-export { Root };
+const wrapPageElement = ({
+  element,
+  props: { path },
+}: WrapPageElementBrowserArgs): ReactNode => <Root path={path}>{element}</Root>;
+
+export { Root, wrapPageElement };


### PR DESCRIPTION
Previously `wrapPageElement` was only used for the browser and not
for the server, which caused ssr pages to have extra elements and
styles. This commit fixes that by making the server also generate
pages using the `Root` component