### PR TITLE
refactor: replace `scrollIntoView` with spring animation

### DIFF
--- a/cypress/integration/projects/laura-lea.ts
+++ b/cypress/integration/projects/laura-lea.ts
@@ -1,5 +1,6 @@
 context('Laura Lea', () => {
   const elements = {
+    root: '#gatsby-focus-wrapper > div',
     title: 'h1',
     loadingBar: 'component-loading-bar > div',
     loadMore: 'component-load-more > div',
@@ -34,7 +35,12 @@ context('Laura Lea', () => {
     slideImage: 'component-slide component-image img',
   };
 
-  beforeEach(() => cy.visit('/projects/laura-lea'));
+  beforeEach(() => {
+    cy.visit('/projects/laura-lea');
+    cy.get(elements.root)
+      .should('exist')
+      .and('not.have.css', 'position', 'fixed');
+  });
 
   it('should display title', () => {
     cy.get(elements.title).should('have.text', 'Laura Lea');

--- a/cypress/integration/site.ts
+++ b/cypress/integration/site.ts
@@ -46,18 +46,23 @@ it('should navigate between projects', () => {
   cy.get(elements.footerLink).should('be.visible');
 });
 
-it('should scroll on page route', () => {
+it('should reset scroll on page route', () => {
   cy.window().then(({ scrollY }) => expect(scrollY).to.equal(0));
   cy.get(elements.navLink).should('contain.text', 'HKFD').click();
-  cy.window().then(({ scrollY }) => expect(scrollY).not.to.be.closeTo(0, 100));
-  cy.get(elements.title).should('not.contain.text', 'Raj');
+  cy.get(elements.title)
+    .should('not.contain.text', 'Raj')
+    .and('contain.text', 'HKFD');
   cy.window().then(({ scrollY }) => expect(scrollY).to.equal(0));
 
   cy.go('back');
-  cy.get(elements.title).should('not.contain.text', 'Hkfd');
-  cy.window().then(({ scrollY }) => expect(scrollY).not.to.be.closeTo(0, 100));
+  cy.get(elements.title)
+    .should('not.contain.text', 'HKFD')
+    .and('contain.text', 'Raj');
+  cy.window().then(({ scrollY }) => expect(scrollY).to.equal(0));
 
   cy.go('forward');
-  cy.get(elements.title).should('not.contain.text', 'Raj');
+  cy.get(elements.title)
+    .should('not.contain.text', 'Raj')
+    .and('contain.text', 'HKFD');
   cy.window().then(({ scrollY }) => expect(scrollY).to.equal(0));
 });

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,6 @@
 import './src/styles/reset.css';
 import './src/styles/global.css';
 
-import smoothscroll from 'smoothscroll-polyfill';
 import 'zone.js/dist/zone';
 import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter';
 import { init } from '@sentry/react';
@@ -13,21 +12,6 @@ init({
   enabled: process.env.NODE_ENV !== 'development',
 });
 
-smoothscroll.polyfill();
-
-export const shouldUpdateScroll = ({
-  routerProps: {
-    location: { action },
-  },
-}) => {
-  if (action !== 'PUSH') return true;
-
-  const intros = document.getElementsByClassName('intro');
-  const nextIntro = intros[intros.length - 1];
-  if (!nextIntro) return false;
-
-  nextIntro.scrollIntoView({ behavior: 'smooth' });
-  return false;
-};
+export const shouldUpdateScroll = () => false;
 
 export { wrapPageElement } from './src/components/root';

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "react-helmet": "^6.0.0-beta.2",
     "react-spring": "^8.0.27",
     "rxjs": "6.6.3",
-    "smoothscroll-polyfill": "^0.4.4",
     "tslib": "^1.13.0",
     "zone.js": "0.10.3"
   },

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -10,6 +10,7 @@ const Header: FC = () => {
     height: '100%',
     transform: 'translateY(-50%)',
     config: { tension: 350 },
+    delay: 250,
   });
 
   return (

--- a/src/components/layout/intro/intro.tsx
+++ b/src/components/layout/intro/intro.tsx
@@ -25,7 +25,7 @@ const Intro: FC<Props> = ({ title, role, description, url, tags }) => {
     tags && tags.map((tag, i) => <span key={i}>{tag}</span>);
 
   return (
-    <IntroStyled className="intro">
+    <IntroStyled>
       <Project>
         <ProjectMeta>
           <h1>{title}</h1>

--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -17,9 +17,21 @@ type Props = InferProps<typeof propTypes>;
 
 const Root: FC<Props> = ({ path, children }) => {
   const transitions = useTransition(children, path, {
-    from: { transform: 'translateY(0%)' },
-    leave: { transform: 'translateY(-100%)' },
-    config: config.slow,
+    from: {
+      position: 'relative',
+      top: 0,
+      left: 0,
+      right: 0,
+      background: '#fff',
+      transform: 'translateY(100vh)',
+    },
+    leave: { transform: 'translateY(-125vh)', zIndex: -1 },
+    enter: [
+      { position: 'fixed', transform: 'translateY(100vh)' },
+      { position: 'fixed', transform: 'translateY(0vh)' },
+      { position: 'relative' },
+    ],
+    config: config.stiff,
   });
 
   const transition = ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -14829,11 +14829,6 @@ slugify@^1.4.0:
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
   integrity sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==
 
-smoothscroll-polyfill@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
-  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
-
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
Previously in order to scroll down to the next project
`scrollIntoView` was used. There are no options to customise the
easing however, and it has to be polyfilled. This commit replaces
it with react spring instead.
Note that we do lose the ability to maintain previous scroll
position on forward/back because of `position: fixed`, but since
the site is a linear journey it shouldnt be a major problem