### PR TITLE
ci: remove commitlint step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
           name: yarn
           command: yarn --frozen-lockfile
       - run:
-          name: commitlint
-          command: yarn commitlint --from origin/master --to ${CIRCLE_SHA1} -V
-      - run:
           name: eslint
           command: yarn eslint "**/*.{tsx,ts,js}" --max-warnings=0
       - run:


### PR DESCRIPTION
`@commitlint/config-conventional` was updated in 9.0.0 to add a max
body line length check. Dependabot is creating commits with a body
line length above 100 characters, causing the job to fail. This
commit temporarily removes the commitlint ci step until the
dependabot commit messages can be customised